### PR TITLE
Making whitelist and blacklist case insensitive

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -38,9 +38,9 @@ Usages
 
 **is\_safe\_username** takes the following optional arguments:
 
--  ``whitelist``: a list of words that should be considered as always
+-  ``whitelist``: a case insensitive list of words that should be considered as always
    safe. Default: ``[]``
--  ``blacklist``: a list of words that should be considered as unsafe. Default: ``[]``
+-  ``blacklist``: a case insensitive list of words that should be considered as unsafe. Default: ``[]``
 -  ``max_length``: specify the maximun character a username can have. Default: ``None``
 -  ``regex``: regular expression string that must pass before the banned
    words is checked.

--- a/usernames/validators.py
+++ b/usernames/validators.py
@@ -28,8 +28,8 @@ def is_safe_username(
     if not re.match(regex, username):
         return False
     wordlist = get_reserved_wordlist()
-    whitelist = set(whitelist)
-    blacklist = set(blacklist)
+    whitelist = set([each_whitelisted_name.lower() for each_whitelisted_name in whitelist])
+    blacklist = set([each_blacklisted_name.lower() for each_blacklisted_name in blacklist])
     wordlist = wordlist - whitelist
     wordlist = wordlist.union(blacklist)
     return False if username.lower() in wordlist else True


### PR DESCRIPTION
Doing a case insensitive match on the whitelist and blacklist list passed to the `is_safe_username` method.

This is the code behaviour right now
```
is_safe_username('hello', blacklist=['Hello'])                          
True

is_safe_username('hello', blacklist=['hello'])                         
False
```

This is the code behaviour as a part of this pull request
```
is_safe_username('hello', blacklist=['Hello'])                          
False

is_safe_username('hello', blacklist=['HELLO'])                          
False

is_safe_username('hello', blacklist=['hello'])                         
False
```